### PR TITLE
Update checkout and setup-dotnet actions to v4

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,12 +30,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.x
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-test
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
             6.x

--- a/src/ForEvolve.ExceptionMapper/ForEvolve.ExceptionMapper.csproj
+++ b/src/ForEvolve.ExceptionMapper/ForEvolve.ExceptionMapper.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>$(FETargetFrameworks)</TargetFrameworks>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Update checkout and setup-dotnet actions to v4 to remove the "Node.js 16 actions are deprecated" notice. #11
- Fix missing property to include README file. #10